### PR TITLE
Change requestBuild url to use build.number not build.id

### DIFF
--- a/app/services/Drone.js
+++ b/app/services/Drone.js
@@ -17,7 +17,7 @@ module.exports = function() {
     },
     requestBuild = function(build, callback) {
       request({
-        url: self.configuration.url + '/api/repos/' + self.configuration.repo + '/builds/' + build.id,
+        url: self.configuration.url + '/api/repos/' + self.configuration.repo + '/builds/' + build.number,
         json: true,
         headers: {
           'Authorization': 'Bearer ' + self.configuration.token


### PR DESCRIPTION
According to drone documentation on http://readme.drone.io/api/build-endpoint, the correct endpoint to get the build detail is: 

`GET /api/repos/{owner}/{name}/builds/{number}`